### PR TITLE
Add speaker diarization and labeling UI

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -18,6 +18,7 @@ import { type Collection } from "./types";
 import { fetchCollections } from "./api";
 import Landing from "./pages/Landing";
 import Playlist from "./pages/Playlist";
+import Labeler from "./pages/Labeler";
 import { Link, useLocation } from "react-router-dom";
 import { FolderOpen, Home } from "lucide-react";
 import { ThemeProvider } from "./components/theme-provider";
@@ -36,6 +37,10 @@ function App() {
             <Routes>
               <Route path="/" element={<Landing />} />
               <Route path="/playlist/:collectionName" element={<Playlist />} />
+              <Route
+                path="/label/:collectionName/:videoTitle"
+                element={<Labeler />}
+              />
             </Routes>
           </main>
         </SidebarProvider>

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -1,4 +1,9 @@
-import type { Collection, SearchResponse, CollectionVideos } from "./types";
+import type {
+  Collection,
+  SearchResponse,
+  CollectionVideos,
+  DiarizationFile,
+} from "./types";
 
 const API_BASE_URL = "http://localhost:8001";
 
@@ -38,4 +43,37 @@ export async function fetchCollectionVideos(
     throw new Error("Failed to fetch collection videos");
   }
   return response.json();
+}
+
+export async function fetchDiarization(
+  collection: string,
+  video: string
+): Promise<DiarizationFile> {
+  const encoded = encodeURIComponent(video);
+  const response = await fetch(
+    `${API_BASE_URL}/collections/${collection}/diarization/${encoded}`
+  );
+  if (!response.ok) {
+    throw new Error("Failed to fetch diarization");
+  }
+  return response.json();
+}
+
+export async function saveDiarization(
+  collection: string,
+  video: string,
+  data: DiarizationFile
+): Promise<void> {
+  const encoded = encodeURIComponent(video);
+  const response = await fetch(
+    `${API_BASE_URL}/collections/${collection}/diarization/${encoded}`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(data),
+    }
+  );
+  if (!response.ok) {
+    throw new Error("Failed to save diarization");
+  }
 }

--- a/client/src/components/VideoGrid.tsx
+++ b/client/src/components/VideoGrid.tsx
@@ -6,6 +6,7 @@ import {
   CardTitle,
 } from "./ui/card";
 import { Youtube, FolderX } from "lucide-react";
+import { Link } from "react-router-dom";
 
 interface VideoGridProps {
   videos: string[];
@@ -40,25 +41,30 @@ export default function VideoGrid({ videos, collectionName }: VideoGridProps) {
 
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
         {videos.map((video, index) => (
-          <Card key={index} className="hover:shadow-md transition-shadow">
-            <CardHeader className="pb-3">
-              <div className="flex items-start gap-3">
-                <div className="flex-shrink-0">
-                  <div className="w-12 h-12 bg-red-100 rounded-lg flex items-center justify-center dark:bg-red-900/20">
-                    <Youtube className="w-6 h-6 text-red-600 dark:text-red-400" />
+          <Link
+            key={index}
+            to={`/label/${collectionName}/${encodeURIComponent(video)}`}
+          >
+            <Card className="hover:shadow-md transition-shadow">
+              <CardHeader className="pb-3">
+                <div className="flex items-start gap-3">
+                  <div className="flex-shrink-0">
+                    <div className="w-12 h-12 bg-red-100 rounded-lg flex items-center justify-center dark:bg-red-900/20">
+                      <Youtube className="w-6 h-6 text-red-600 dark:text-red-400" />
+                    </div>
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <CardTitle className="text-sm line-clamp-2 leading-tight">
+                      {video}
+                    </CardTitle>
+                    <CardDescription className="text-xs mt-1">
+                      YouTube Video
+                    </CardDescription>
                   </div>
                 </div>
-                <div className="flex-1 min-w-0">
-                  <CardTitle className="text-sm line-clamp-2 leading-tight">
-                    {video}
-                  </CardTitle>
-                  <CardDescription className="text-xs mt-1">
-                    YouTube Video
-                  </CardDescription>
-                </div>
-              </div>
-            </CardHeader>
-          </Card>
+              </CardHeader>
+            </Card>
+          </Link>
         ))}
       </div>
     </div>

--- a/client/src/pages/Labeler.tsx
+++ b/client/src/pages/Labeler.tsx
@@ -1,0 +1,110 @@
+import { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+import { fetchDiarization, saveDiarization } from "../api";
+import type { DiarizationSegment } from "../types";
+import { Input } from "../components/ui/input";
+import { Button } from "../components/ui/button";
+
+export default function Labeler() {
+  const { collectionName, videoTitle } = useParams<{
+    collectionName: string;
+    videoTitle: string;
+  }>();
+  const [segments, setSegments] = useState<DiarizationSegment[]>([]);
+  const [labels, setLabels] = useState<Record<string, string>>({});
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function load() {
+      if (!collectionName || !videoTitle) return;
+      try {
+        const data = await fetchDiarization(collectionName, videoTitle);
+        setSegments(data.segments);
+        const map: Record<string, string> = {};
+        data.segments.forEach((s) => {
+          map[s.speaker] = s.label || s.speaker;
+        });
+        setLabels(map);
+      } catch (err) {
+        setError(
+          err instanceof Error ? err.message : "Failed to load diarization"
+        );
+      } finally {
+        setLoading(false);
+      }
+    }
+    load();
+  }, [collectionName, videoTitle]);
+
+  const handleLabelChange = (speaker: string, value: string) => {
+    setLabels((prev) => ({ ...prev, [speaker]: value }));
+    setSegments((prev) =>
+      prev.map((s) =>
+        s.speaker === speaker ? { ...s, label: value } : s
+      )
+    );
+  };
+
+  const handleSave = async () => {
+    if (!collectionName || !videoTitle) return;
+    try {
+      setSaving(true);
+      await saveDiarization(collectionName, videoTitle, { segments });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to save");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading) {
+    return <div className="p-8">Loading...</div>;
+  }
+  if (error) {
+    return <div className="p-8 text-destructive">{error}</div>;
+  }
+
+  const speakers = Object.keys(labels);
+
+  return (
+    <div className="p-8 space-y-6">
+      <h1 className="text-2xl font-bold">{videoTitle}</h1>
+      <div className="space-y-2">
+        {speakers.map((sp) => (
+          <div key={sp} className="flex items-center gap-2">
+            <span className="w-24 text-sm">{sp}</span>
+            <Input
+              value={labels[sp]}
+              onChange={(e) => handleLabelChange(sp, e.target.value)}
+            />
+          </div>
+        ))}
+      </div>
+      <Button onClick={handleSave} disabled={saving}>
+        {saving ? "Saving..." : "Save"}
+      </Button>
+      <table className="w-full text-sm border mt-4">
+        <thead>
+          <tr className="bg-muted">
+            <th className="p-2 text-left">Start</th>
+            <th className="p-2 text-left">End</th>
+            <th className="p-2 text-left">Speaker</th>
+            <th className="p-2 text-left">Label</th>
+          </tr>
+        </thead>
+        <tbody>
+          {segments.map((seg, idx) => (
+            <tr key={idx} className="border-t">
+              <td className="p-2">{seg.start.toFixed(2)}</td>
+              <td className="p-2">{seg.end.toFixed(2)}</td>
+              <td className="p-2">{seg.speaker}</td>
+              <td className="p-2">{seg.label || ""}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -10,7 +10,7 @@ export interface SearchResult {
   start_timestamp: string;
   end_timestamp: string;
   similarity_score?: number;
-  metadata: Record<string, any>;
+  metadata: Record<string, unknown>;
 }
 
 export interface SearchResponse {
@@ -24,4 +24,15 @@ export interface CollectionVideos {
   collection: string;
   video_count: number;
   videos: string[];
+}
+
+export interface DiarizationSegment {
+  start: number;
+  end: number;
+  speaker: string;
+  label?: string;
+}
+
+export interface DiarizationFile {
+  segments: DiarizationSegment[];
 }

--- a/pipeline/api.py
+++ b/pipeline/api.py
@@ -19,6 +19,8 @@ from typing import List, Dict, Any, Optional
 import chromadb
 from pydantic import BaseModel
 import os
+from pathlib import Path
+import json
 
 app = FastAPI(
     title="YouTube Transcript Search API",
@@ -209,6 +211,53 @@ async def get_collection_videos(collection_name: str):
             raise HTTPException(
                 status_code=500, detail=f"Error getting videos: {str(e)}"
             )
+
+
+BASE_PLAYLIST_DIR = Path(__file__).parent / "playlists"
+
+
+class DiarizationSegment(BaseModel):
+    start: float
+    end: float
+    speaker: str
+    label: Optional[str] = None
+
+
+class DiarizationFile(BaseModel):
+    segments: List[DiarizationSegment]
+
+
+@app.get(
+    "/collections/{collection_name}/diarization/{video_title}",
+    response_model=DiarizationFile,
+)
+async def get_diarization(collection_name: str, video_title: str):
+    path = (
+        BASE_PLAYLIST_DIR
+        / collection_name
+        / video_title
+        / f"{video_title}.diarization.json"
+    )
+    if not path.exists():
+        raise HTTPException(status_code=404, detail="Diarization not found")
+    with open(path) as f:
+        return json.load(f)
+
+
+@app.post("/collections/{collection_name}/diarization/{video_title}")
+async def save_diarization(
+    collection_name: str, video_title: str, diarization: DiarizationFile
+):
+    path = (
+        BASE_PLAYLIST_DIR
+        / collection_name
+        / video_title
+        / f"{video_title}.diarization.json"
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(diarization.dict(), f)
+    return {"status": "saved"}
 
 
 if __name__ == "__main__":

--- a/pipeline/diarize.py
+++ b/pipeline/diarize.py
@@ -1,0 +1,52 @@
+"""Utilities for running speaker diarization on playlist audio files."""
+from __future__ import annotations
+
+import json
+import os
+from typing import List, Dict
+
+from pyannote.audio import Pipeline
+import torch
+
+
+def load_pipeline() -> Pipeline:
+    token = os.getenv("HF_TOKEN")
+    pipeline = Pipeline.from_pretrained(
+        "pyannote/speaker-diarization-3.1", use_auth_token=token
+    )
+    if torch.cuda.is_available():
+        pipeline.to(torch.device("cuda"))
+    return pipeline
+
+
+def diarize_audio(pipeline: Pipeline, audio_path: str) -> List[Dict[str, float]]:
+    diarization = pipeline(audio_path)
+    segments: List[Dict[str, float]] = []
+    for turn, _, speaker in diarization.itertracks(yield_label=True):
+        segments.append(
+            {
+                "start": float(round(turn.start, 2)),
+                "end": float(round(turn.end, 2)),
+                "speaker": speaker,
+            }
+        )
+    return segments
+
+
+def diarize_playlist(playlist_path: str) -> List[str]:
+    pipeline = load_pipeline()
+    results: List[str] = []
+    for folder in os.listdir(playlist_path):
+        folder_path = os.path.join(playlist_path, folder)
+        if not os.path.isdir(folder_path):
+            continue
+        for file in os.listdir(folder_path):
+            if not file.endswith(".wav"):
+                continue
+            audio_path = os.path.join(folder_path, file)
+            segments = diarize_audio(pipeline, audio_path)
+            out_path = audio_path.replace(".wav", ".diarization.json")
+            with open(out_path, "w") as f:
+                json.dump({"segments": segments}, f)
+            results.append(out_path)
+    return results

--- a/pipeline/main.py
+++ b/pipeline/main.py
@@ -35,6 +35,7 @@ from typing import Optional
 try:
     from download import process_playlist
     from transcribe import transcribe_playlist
+    from diarize import diarize_playlist
     from db import process_collection, search_collection
 except ImportError as e:
     print(f"Error importing pipeline modules: {e}")
@@ -116,6 +117,23 @@ class PipelineOrchestrator:
 
         except Exception as e:
             print(f"❌ Transcription error: {e}")
+            return False
+
+    def diarize_collection(self, collection_name: str) -> bool:
+        """Generate speaker diarization segments for a collection."""
+        collection_path = self.playlists_dir / collection_name
+
+        if not collection_path.exists():
+            print(f"❌ Collection directory not found: {collection_path}")
+            return False
+
+        print(f"🗣️ Diarizing collection: {collection_name}")
+        try:
+            diarize_playlist(str(collection_path))
+            print("✅ Diarization completed!")
+            return True
+        except Exception as e:
+            print(f"❌ Diarization error: {e}")
             return False
 
     def index_collection(self, collection_name: str) -> bool:
@@ -215,8 +233,13 @@ class PipelineOrchestrator:
         if not self.transcribe_collection(collection_name):
             return False
 
-        # Step 3: Index
-        print("\n🗂️  STEP 3: Indexing in ChromaDB...")
+        # Step 3: Diarize
+        print("\n🗣️ STEP 3: Speaker diarization...")
+        if not self.diarize_collection(collection_name):
+            return False
+
+        # Step 4: Index
+        print("\n🗂️  STEP 4: Indexing in ChromaDB...")
         if not self.index_collection(collection_name):
             return False
 
@@ -359,6 +382,14 @@ Examples:
         "--collection", "-c", required=True, help="Collection name"
     )
 
+    # Diarize command
+    diarize_parser = subparsers.add_parser(
+        "diarize", help="Generate speaker diarization"
+    )
+    diarize_parser.add_argument(
+        "--collection", "-c", required=True, help="Collection name"
+    )
+
     # Index command
     index_parser = subparsers.add_parser("index", help="Index transcripts in ChromaDB")
     index_parser.add_argument(
@@ -424,6 +455,10 @@ Examples:
         success = orchestrator.transcribe_collection(args.collection)
         sys.exit(0 if success else 1)
 
+    elif args.command == "diarize":
+        success = orchestrator.diarize_collection(args.collection)
+        sys.exit(0 if success else 1)
+
     elif args.command == "index":
         success = orchestrator.index_collection(args.collection)
         sys.exit(0 if success else 1)
@@ -451,6 +486,3 @@ Examples:
 
 if __name__ == "__main__":
     main()
-
-
-print(o)


### PR DESCRIPTION
## Summary
- add PyAnnote-based diarization module and integrate it into pipeline orchestration with a new `diarize` step and CLI command
- expose diarization data over API for reading and writing
- add frontend labeling UI to edit speaker names and link to it from the playlist view

## Testing
- `python -m py_compile pipeline/diarize.py pipeline/main.py pipeline/api.py`
- `npm run lint` *(fails: react-refresh/only-export-components, Unexpected any)*
- `npm run build` *(fails: TypeScript configuration issues such as missing jsx flag)*

------
https://chatgpt.com/codex/tasks/task_e_6894e61b1f90832383554bec91124eef